### PR TITLE
Allow recreation of `azuresql_aad_user` resources after out-of-band deletion

### DIFF
--- a/internal/provider/aad_user_resource.go
+++ b/internal/provider/aad_user_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -92,6 +93,11 @@ func (resource externalUserResource) Read(context context.Context, request tfsdk
 
 	user, err := resource.provider.manager.GetLoginUser(context, data.LoginName.Value, data.Database.Value)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			response.State.RemoveResource(context)
+			return
+		}
+
 		response.Diagnostics.AddError("Failed to read user", err.Error())
 		return
 	}


### PR DESCRIPTION
Automatically remove `azuresql_aad_user` resources from state if the remote SQL server no longer contains the user.

Came about due to scenarios where we have Azure SQL database restorations or rollbacks that wipe out the user **after** it has been inserted by Terraform - at which point manual intervention via `terraform state rm` becomes necessary to allow Terraform recreation of it.